### PR TITLE
Add Caching of the Http Data to Z-wave database

### DIFF
--- a/HSPI_ZWaveParameters.csproj
+++ b/HSPI_ZWaveParameters.csproj
@@ -99,6 +99,8 @@
     <Compile Include="Hspi\HSPI.cs" />
     <Compile Include="Hspi\IDeviceConfigPage.cs" />
     <Compile Include="Hspi\IZWaveConnection.cs" />
+    <Compile Include="Hspi\OpenZWaveDB\FileCachingHttpQuery.cs" />
+    <Compile Include="Hspi\OpenZWaveDB\IHttpQueryMaker.cs" />
     <Compile Include="Hspi\OpenZWaveDB\ZWaveCommandClass.cs" />
     <Compile Include="Hspi\OpenZWaveDB\ZWaveCommandClassChannel.cs" />
     <Compile Include="Hspi\OpenZWaveDB\ZWaveDevice.cs" />
@@ -151,9 +153,15 @@
       <Version>1.3.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
-      <Version>5.0.3</Version>
+      <Version>6.0.0</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="MonkeyCache">
+      <Version>1.5.2</Version>
+    </PackageReference>
+    <PackageReference Include="MonkeyCache.FileStore">
+      <Version>1.5.2</Version>
     </PackageReference>
     <PackageReference Include="MSBuildTasks">
       <Version>1.5.0.235</Version>
@@ -176,7 +184,10 @@
       <Version>4.7.12</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Drawing.Primitives">
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO">
       <Version>4.3.0</Version>
@@ -217,9 +228,6 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Drawing" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <ArtifactsDirectory>$(OutputPath)\Artifacts</ArtifactsDirectory>
@@ -250,6 +258,8 @@
       <ReleaseFiles Include="$(OutputPath)\System.Memory.dll" />
       <ReleaseFiles Include="$(OutputPath)\System.Numerics.Vectors.dll" />
       <ReleaseFiles Include="$(OutputPath)\System.Runtime.CompilerServices.Unsafe.dll" />
+      <ReleaseFiles Include="$(OutputPath)\MonkeyCache.dll" />
+      <ReleaseFiles Include="$(OutputPath)\MonkeyCache.FileStore.dll" />
       <ReleaseFiles Include="$(OutputPath)\install.txt" />
     </ItemGroup>
     <Copy SourceFiles="@(ReleaseFiles)" DestinationFolder="$(ArtifactsDirectory)" />

--- a/Hspi/DeviceConfigPage.cs
+++ b/Hspi/DeviceConfigPage.cs
@@ -18,12 +18,12 @@ namespace Hspi
 {
     internal class DeviceConfigPage : IDeviceConfigPage
     {
-        public DeviceConfigPage(IZWaveConnection zwaveConnection, int deviceOrFeatureRef, HttpClient? httpClient = null)
+        public DeviceConfigPage(IZWaveConnection zwaveConnection, int deviceOrFeatureRef, IHttpQueryMaker httpQueryMaker)
         {
             logger.Debug(Invariant($"Creating Page for {deviceOrFeatureRef}"));
             this.zwaveConnection = zwaveConnection;
             this.deviceOrFeatureRef = deviceOrFeatureRef;
-            this.httpClient = httpClient;
+            this.httpQueryMaker = httpQueryMaker;
         }
 
         public ZWaveInformation? Data { get; private set; }
@@ -34,7 +34,7 @@ namespace Hspi
             var zwaveData = zwaveConnection.GetDeviceZWaveData(this.deviceOrFeatureRef);
 
             var openZWaveData = new OpenZWaveDBInformation(zwaveData.ManufactureId, zwaveData.ProductType,
-                                                           zwaveData.ProductId, zwaveData.Firmware, httpClient);
+                                                           zwaveData.ProductId, zwaveData.Firmware, httpQueryMaker);
 
             await openZWaveData.Update(cancellationToken).ConfigureAwait(false);
 
@@ -337,7 +337,7 @@ namespace Hspi
         private const string ZWaveParameterPrefix = "zw_parameter_";
         private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
         private readonly int deviceOrFeatureRef;
-        private readonly HttpClient? httpClient;
+        private readonly IHttpQueryMaker httpQueryMaker;
         private readonly IZWaveConnection zwaveConnection;
         private int id = 0;
         private Page? page;

--- a/Hspi/DeviceConfigPage.cs
+++ b/Hspi/DeviceConfigPage.cs
@@ -271,6 +271,8 @@ namespace Hspi
 
         private LabelView? CreateDescriptionViewForParameter(int parameterId)
         {
+            CheckInitialized();
+
             var list = Data.DescriptionForParameter(parameterId);
             if (list.Count > 0)
             {

--- a/Hspi/IDeviceConfigPage.cs
+++ b/Hspi/IDeviceConfigPage.cs
@@ -3,13 +3,15 @@ using Hspi.OpenZWaveDB;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Hspi
 {
     internal interface IDeviceConfigPage
     {
-        ZWaveInformation Data { get; }
+        ZWaveInformation? Data { get; }
 
-        Page GetPage();
+        Page? GetPage();
 
         Task BuildConfigPage(CancellationToken cancellationToken);
 

--- a/Hspi/OpenZWaveDB/FileCachingHttpQuery.cs
+++ b/Hspi/OpenZWaveDB/FileCachingHttpQuery.cs
@@ -1,0 +1,74 @@
+﻿using MonkeyCache;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Hspi.OpenZWaveDB
+{
+    internal class FileCachingHttpQuery : IHttpQueryMaker
+    {
+        static FileCachingHttpQuery()
+        {
+            var handler = new HttpClientHandler()
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+
+            httpClientGlobal = new HttpClient(handler, true);
+        }
+
+        public FileCachingHttpQuery(HttpClient? httpClient = null)
+        {
+            using var process = System.Diagnostics.Process.GetCurrentProcess();
+
+            string mainExeFile = process.MainModule.FileName;
+            string hsDir = Path.GetDirectoryName(mainExeFile);
+            string cachePath = Path.Combine(hsDir, "data", PlugInData.PlugInId, "cache");
+
+            barrel = MonkeyCache.FileStore.Barrel.Create(cachePath);
+            this.httpClient = httpClient ?? httpClientGlobal;
+        }
+
+        public async Task<string> GetResponseAsString(string url, CancellationToken cancellationToken)
+        {
+            logger.Info("Getting data from " + url);
+            if (barrel.Exists(url))
+            {
+                _ = Task.Run(async () => await UpdateCache(url, cancellationToken), cancellationToken);
+                return barrel.Get<string>(url);
+            }
+
+            string json = await GetResponseString(url, cancellationToken).ConfigureAwait(false);
+            return json;
+
+            async Task<string> GetResponseString(string url, CancellationToken cancellationToken)
+            {
+                var result = await httpClient.GetAsync(new Uri(url, UriKind.Absolute), cancellationToken).ConfigureAwait(false);
+                result.EnsureSuccessStatusCode();
+                var json = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
+                barrel.Add(url, json, TimeSpan.MaxValue);
+                return json;
+            }
+
+            async Task UpdateCache(string url, CancellationToken cancellationToken)
+            {
+                var result = await httpClient.GetAsync(new Uri(url, UriKind.Absolute), cancellationToken).ConfigureAwait(false);
+                if (result.IsSuccessStatusCode)
+                {
+                    var json = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    barrel.Add(url, json, TimeSpan.MaxValue);
+                }
+            }
+        }
+
+        private static readonly NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+        private readonly IBarrel barrel;
+        private readonly HttpClient httpClient;
+        private static readonly HttpClient httpClientGlobal;
+    }
+}

--- a/Hspi/OpenZWaveDB/IHttpQueryMaker.cs
+++ b/Hspi/OpenZWaveDB/IHttpQueryMaker.cs
@@ -1,0 +1,11 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hspi.OpenZWaveDB
+{
+    public interface IHttpQueryMaker
+    {
+        Task<string> GetResponseAsString(string url, CancellationToken cancellationToken);
+    }
+}

--- a/Hspi/OpenZWaveDB/IHttpQueryMaker.cs
+++ b/Hspi/OpenZWaveDB/IHttpQueryMaker.cs
@@ -6,6 +6,8 @@ namespace Hspi.OpenZWaveDB
 {
     public interface IHttpQueryMaker
     {
+#pragma warning disable CA1054 // URI-like parameters should not be strings
         Task<string> GetResponseAsString(string url, CancellationToken cancellationToken);
+#pragma warning restore CA1054 // URI-like parameters should not be strings
     }
 }

--- a/Hspi/PlugIn.cs
+++ b/Hspi/PlugIn.cs
@@ -31,7 +31,7 @@ namespace Hspi
                 var page = CreateDeviceConfigPage(deviceOrFeatureRef);
                 page.BuildConfigPage(CancellationToken.None).ResultForSync();
                 cacheForUpdate[deviceOrFeatureRef] = page;
-                return page?.GetPage()?.ToJsonString() ?? throw new Exception("Page is unexpectely null")
+                return page?.GetPage()?.ToJsonString() ?? throw new Exception("Page is unexpectely null");
             }
             catch (Exception ex)
             {

--- a/Hspi/PlugIn.cs
+++ b/Hspi/PlugIn.cs
@@ -31,7 +31,7 @@ namespace Hspi
                 var page = CreateDeviceConfigPage(deviceOrFeatureRef);
                 page.BuildConfigPage(CancellationToken.None).ResultForSync();
                 cacheForUpdate[deviceOrFeatureRef] = page;
-                return page.GetPage().ToJsonString();
+                return page?.GetPage()?.ToJsonString() ?? throw new Exception("Page is unexpectely null")
             }
             catch (Exception ex)
             {
@@ -158,7 +158,7 @@ namespace Hspi
                     }
 
                     var connection = CreateZWaveConnection();
-                    int value = connection.GetConfiguration(homeId, nodeId.Value, parameter.Value).ResultForSync();
+                    int value = connection.GetConfiguration(homeId!, nodeId.Value, parameter.Value).ResultForSync();
 
                     return JsonConvert.SerializeObject(new ZWaveParameterGetResult()
                     {

--- a/Hspi/PlugIn.cs
+++ b/Hspi/PlugIn.cs
@@ -1,6 +1,7 @@
 ﻿using HomeSeer.Jui.Views;
 using HomeSeer.PluginSdk;
 using Hspi.Exceptions;
+using Hspi.OpenZWaveDB;
 using Hspi.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -65,7 +66,7 @@ namespace Hspi
 
         protected virtual IDeviceConfigPage CreateDeviceConfigPage(int deviceOrFeatureRef)
         {
-            return new DeviceConfigPage(CreateZWaveConnection(), deviceOrFeatureRef);
+            return new DeviceConfigPage(CreateZWaveConnection(), deviceOrFeatureRef, new FileCachingHttpQuery());
         }
 
         protected virtual IZWaveConnection CreateZWaveConnection()

--- a/Hspi/ZWaveInformationDBDisplayExtensions.cs
+++ b/Hspi/ZWaveInformationDBDisplayExtensions.cs
@@ -63,7 +63,7 @@ namespace Hspi
                 string? longerOne = descList.OrderByDescending(x => x?.Length ?? 0).FirstOrDefault();
 
                 if (!string.IsNullOrWhiteSpace(longerOne) && longerOne != parameter.Label) {
-                    list.Add(longerOne);
+                    list.Add(longerOne!);
                 }
 
                 if (!parameter.HasOptions)          

--- a/install.txt
+++ b/install.txt
@@ -11,6 +11,8 @@ System.Collections.Immutable.dll,.\bin\ZWaveParameters,0
 System.Memory.dll,.\bin\ZWaveParameters,0
 System.Numerics.Vectors.dll,.\bin\ZWaveParameters,0
 System.Runtime.CompilerServices.Unsafe.dll,.\bin\ZWaveParameters,0
+MonkeyCache.dll,.\bin\ZWaveParameters,0
+MonkeyCache.FileStore.dll,.\bin\ZWaveParameters,0
 
 
  

--- a/tests/DeviceConfigPageTest.cs
+++ b/tests/DeviceConfigPageTest.cs
@@ -3,7 +3,6 @@ using Hspi;
 using Hspi.OpenZWaveDB;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Moq.Contrib.HttpClient;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -30,10 +29,10 @@ namespace HSPI_ZWaveParametersTest
         {
             int deviceRef = 3746;
             var zwaveData = TestHelper.HomeseerDimmerZWaveData;
-            var httpHandler = TestHelper.CreateHomeseerDimmerHttpHandler();
+            var httpQueryMock = TestHelper.CreateHomeseerDimmerHttpHandler();
 
             var mock = SetupZWaveConnection(deviceRef, zwaveData);
-            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpHandler.CreateClient());
+            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpQueryMock.Object);
 
             var changes = PageFactory.CreateGenericPage("id", "name");
 
@@ -83,12 +82,12 @@ namespace HSPI_ZWaveParametersTest
 
         [DataTestMethod]
         [DynamicData(nameof(GetSupportsDeviceConfigPageData), DynamicDataSourceType.Method)]
-        public async Task SupportsDeviceConfigPage(ZWaveData zwaveData, Mock<HttpMessageHandler> httpHandler)
+        public async Task SupportsDeviceConfigPage(ZWaveData zwaveData, Mock<IHttpQueryMaker> httpQueryMock)
         {
             int deviceRef = 34;
             var mock = SetupZWaveConnection(deviceRef, zwaveData);
 
-            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpHandler.CreateClient());
+            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpQueryMock.Object);
             await deviceConfigPage.BuildConfigPage(CancellationToken.None);
             var page = deviceConfigPage.GetPage();
 
@@ -108,7 +107,7 @@ namespace HSPI_ZWaveParametersTest
             // verify script
             VerifyScript((LabelView)page.Views[3], zwaveData.Listening);
 
-            Mock.VerifyAll(mock, httpHandler);
+            Mock.VerifyAll(mock, httpQueryMock);
         }
 
         [TestMethod]
@@ -116,18 +115,18 @@ namespace HSPI_ZWaveParametersTest
         {
             int deviceRef = 334;
             var handler = new Mock<HttpMessageHandler>();
-            var httpclient = handler.CreateClient();
+            var httpQueryMock = new Mock<IHttpQueryMaker>(MockBehavior.Strict);
 
-            handler.SetupRequest(HttpMethod.Get, "https://www.opensmarthouse.org/dmxConnect/api/zwavedatabase/device/list.php?filter=manufacturer:0x0086%200003:0006")
-                               .ReturnsResponse(Resource.AeonLabsOpenZWaveDBDeviceListJson, "application/json");
+            TestHelper.SetupRequest(httpQueryMock, "https://www.opensmarthouse.org/dmxConnect/api/zwavedatabase/device/list.php?filter=manufacturer:0x0086%200003:0006",
+                                    Resource.AeonLabsOpenZWaveDBDeviceListJson);
 
-            handler.SetupRequest(HttpMethod.Get, "https://opensmarthouse.org/dmxConnect/api/zwavedatabase/device/read.php?device_id=75")
-                               .ReturnsResponse("{ database_id:1034}", "application/json");
+            TestHelper.SetupRequest(httpQueryMock, "https://opensmarthouse.org/dmxConnect/api/zwavedatabase/device/read.php?device_id=75",
+                                    "{ database_id:1034}");
 
             var zwaveData = TestHelper.AeonLabsZWaveData;
             var mock = SetupZWaveConnection(deviceRef, zwaveData);
 
-            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpclient);
+            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpQueryMock.Object);
             await deviceConfigPage.BuildConfigPage(CancellationToken.None);
             var page = deviceConfigPage.GetPage();
 
@@ -143,10 +142,10 @@ namespace HSPI_ZWaveParametersTest
         {
             int deviceRef = 3746;
             ZWaveData zwaveData = TestHelper.AeonLabsZWaveData;
-            var httpHandler = TestHelper.CreateAeonLabsSwitchHttpHandler();
+            var httpQueryMock = TestHelper.CreateAeonLabsSwitchHttpHandler();
 
             var mock = SetupZWaveConnection(deviceRef, zwaveData);
-            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpHandler.CreateClient());
+            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpQueryMock.Object);
             await deviceConfigPage.BuildConfigPage(CancellationToken.None);
             return (mock, deviceConfigPage);
         }
@@ -155,10 +154,10 @@ namespace HSPI_ZWaveParametersTest
         {
             int deviceRef = 3746;
             var zwaveData = TestHelper.HomeseerDimmerZWaveData;
-            var httpHandler = TestHelper.CreateHomeseerDimmerHttpHandler();
+            var httpQueryMock = TestHelper.CreateHomeseerDimmerHttpHandler();
 
             var mock = SetupZWaveConnection(deviceRef, zwaveData);
-            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpHandler.CreateClient());
+            var deviceConfigPage = new DeviceConfigPage(mock.Object, deviceRef, httpQueryMock.Object);
             await deviceConfigPage.BuildConfigPage(CancellationToken.None);
             return (mock, deviceConfigPage);
         }

--- a/tests/E2EPlugInTest.cs
+++ b/tests/E2EPlugInTest.cs
@@ -5,7 +5,6 @@ using HomeSeer.PluginSdk.Logging;
 using Hspi;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Moq.Contrib.HttpClient;
 using Moq.Protected;
 using System;
 using System.Collections.Generic;
@@ -42,7 +41,7 @@ namespace HSPI_ZWaveParametersTest
 
             var deviceConfigPage = new DeviceConfigPage(new ZWaveConnection(hsControllerMock.Object),
                                                                             deviceRef,
-                                                                            TestHelper.CreateAeonLabsSwitchHttpHandler().CreateClient());
+                                                                            TestHelper.CreateAeonLabsSwitchHttpHandler().Object);
 
             plugInMock.Protected()
                 .Setup<IDeviceConfigPage>("CreateDeviceConfigPage", deviceRef)

--- a/tests/FileCachingHttpQueryTest.cs
+++ b/tests/FileCachingHttpQueryTest.cs
@@ -1,0 +1,71 @@
+﻿using Hspi.OpenZWaveDB;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Moq.Contrib.HttpClient;
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HSPI_ZWaveParametersTest
+{
+    [TestClass]
+    public class FileCachingHttpQueryTest
+    {
+        [TestMethod]
+        public void DefaultConstructorWithPath()
+        {
+            // checking not throws exception
+            var _ = new FileCachingHttpQuery(cachePath: Path.GetTempPath());
+        }
+
+        [TestMethod]
+        public async Task CacheIsUpdated()
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var httpClient = handler.CreateClient();
+
+            string url = "http://google2.com";
+            string data = "def";
+
+            handler.SetupRequest(HttpMethod.Get, url)
+                                .ReturnsResponse(data, "application/json");
+
+            var obj = new FileCachingHttpQuery(httpClient, 
+                                               Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+
+            Assert.AreEqual(await obj.GetResponseAsString(url, CancellationToken.None), data);
+
+            handler.Verify();
+            handler.Reset();
+
+            handler.SetupRequest(HttpMethod.Get, url)
+                                .ReturnsResponse(HttpStatusCode.Forbidden);
+
+            Assert.AreEqual(await obj.GetResponseAsString(url, CancellationToken.None), data);
+
+            handler.Verify();
+        }
+
+        [TestMethod]
+        public async Task CacheThrowsOnFailure()
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var httpClient = handler.CreateClient();
+
+            string url = "http://google2.com";
+
+            handler.SetupRequest(HttpMethod.Get, url)
+                                .ReturnsResponse(HttpStatusCode.Forbidden);
+
+            var obj = new FileCachingHttpQuery(httpClient, 
+                                               Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(() => obj.GetResponseAsString(url, CancellationToken.None));
+
+            handler.Verify();
+        }
+    }
+}

--- a/tests/HSPI_ZWaveParametersTest.csproj
+++ b/tests/HSPI_ZWaveParametersTest.csproj
@@ -51,6 +51,7 @@
     <Compile Include="DeviceConfigPageTest.cs" />
     <Compile Include="shared\ExceptionHelperTest.cs" />
     <Compile Include="TestHelper.cs" />
+    <Compile Include="FileCachingHttpQueryTest.cs" />
     <Compile Include="ZWaveConnectionTest.cs" />
     <Compile Include="PluginTest.cs" />
     <Compile Include="OpenZWaveDBInformationTest.cs" />
@@ -123,6 +124,9 @@
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.16.1</Version>
+    </PackageReference>
+    <PackageReference Include="Moq.Contrib.HttpClient">
+      <Version>1.3.0</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>2.2.7</Version>

--- a/tests/HSPI_ZWaveParametersTest.csproj
+++ b/tests/HSPI_ZWaveParametersTest.csproj
@@ -86,46 +86,43 @@
       <Version>1.3.1</Version>
     </PackageReference>
     <PackageReference Include="HtmlAgilityPack">
-      <Version>1.11.37</Version>
+      <Version>1.11.38</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>5.0.2</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Options">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Primitives">
-      <Version>5.0.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.16.1</Version>
-    </PackageReference>
-    <PackageReference Include="Moq.Contrib.HttpClient">
-      <Version>1.3.0</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>2.2.7</Version>
@@ -140,7 +137,7 @@
       <Version>4.5.1</Version>
     </PackageReference>
     <PackageReference Include="System.Diagnostics.DiagnosticSource">
-      <Version>5.0.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.IO">
       <Version>4.3.0</Version>
@@ -158,7 +155,7 @@
       <Version>4.3.1</Version>
     </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Security.Cryptography.Algorithms">
       <Version>4.3.1</Version>

--- a/tests/TestHelper.cs
+++ b/tests/TestHelper.cs
@@ -43,6 +43,13 @@ namespace HSPI_ZWaveParametersTest
                 .Returns(true);
         }
 
+        public static void SetupRequest(Mock<IHttpQueryMaker> mock,
+                                        string deviceListUrl, string deviceListJson)
+        {
+            mock.Setup(x => x.GetResponseAsString(deviceListUrl, It.IsAny<CancellationToken>()))
+                               .Returns(Task.FromResult(deviceListJson));
+        }
+
         public static void SetupZWaveDataInHsControllerMock(Mock<IHsController> mock,
                                                             int deviceRef,
                                                             string manufactureId,
@@ -93,14 +100,6 @@ namespace HSPI_ZWaveParametersTest
 
             return mock;
         }
-
-        public static void SetupRequest(Mock<IHttpQueryMaker> mock, 
-                                        string deviceListUrl, string deviceListJson)
-        {
-            mock.Setup(x => x.GetResponseAsString(deviceListUrl, It.IsAny<CancellationToken>()))
-                               .Returns(Task.FromResult(deviceListJson));
-        }
-
         public const string ZWaveInterface = "Z-Wave";
     }
 }

--- a/tests/TestHelper.cs
+++ b/tests/TestHelper.cs
@@ -1,12 +1,14 @@
 ﻿using HomeSeer.PluginSdk;
 using HomeSeer.PluginSdk.Devices;
 using Hspi;
+using Hspi.OpenZWaveDB;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using Moq.Contrib.HttpClient;
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace HSPI_ZWaveParametersTest
 {
@@ -16,7 +18,7 @@ namespace HSPI_ZWaveParametersTest
 
         public static ZWaveData HomeseerDimmerZWaveData => new(0x000C, 0x3036, 0x4447, 23, "56", new Version(5, 15), true);
 
-        public static Mock<HttpMessageHandler> CreateAeonLabsSwitchHttpHandler()
+        public static Mock<IHttpQueryMaker> CreateAeonLabsSwitchHttpHandler()
         {
             return CreateMockHttpHandler("https://www.opensmarthouse.org/dmxConnect/api/zwavedatabase/device/list.php?filter=manufacturer:0x0086%200003:0006",
                                                                 Resource.AeonLabsOpenZWaveDBDeviceListJson,
@@ -24,7 +26,7 @@ namespace HSPI_ZWaveParametersTest
                                                                 Resource.AeonLabsOpenZWaveDBDeviceJson);
         }
 
-        public static Mock<HttpMessageHandler> CreateHomeseerDimmerHttpHandler()
+        public static Mock<IHttpQueryMaker> CreateHomeseerDimmerHttpHandler()
         {
             return CreateMockHttpHandler("https://www.opensmarthouse.org/dmxConnect/api/zwavedatabase/device/list.php?filter=manufacturer:0x000C%204447:3036",
                                          Resource.HomeseerDimmerOpenZWaveDBDeviceListJson,
@@ -81,16 +83,22 @@ namespace HSPI_ZWaveParametersTest
             htmlDocument.LoadHtml(html);
             Assert.AreEqual(htmlDocument.ParseErrors.Count(), 0);
         }
-        private static Mock<HttpMessageHandler> CreateMockHttpHandler(string deviceListUrl, string deviceListJson, string deviceUrl, string deviceJson)
+
+        private static Mock<IHttpQueryMaker> CreateMockHttpHandler(string deviceListUrl, string deviceListJson, string deviceUrl, string deviceJson)
         {
-            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var mock = new Mock<IHttpQueryMaker>(MockBehavior.Strict);
 
-            handler.SetupRequest(HttpMethod.Get, deviceListUrl)
-                               .ReturnsResponse(deviceListJson, "application/json");
+            SetupRequest(mock, deviceListUrl, deviceListJson);
+            SetupRequest(mock, deviceUrl, deviceJson);
 
-            handler.SetupRequest(HttpMethod.Get, deviceUrl)
-                               .ReturnsResponse(deviceJson, "application/json");
-            return handler;
+            return mock;
+        }
+
+        public static void SetupRequest(Mock<IHttpQueryMaker> mock, 
+                                        string deviceListUrl, string deviceListJson)
+        {
+            mock.Setup(x => x.GetResponseAsString(deviceListUrl, It.IsAny<CancellationToken>()))
+                               .Returns(Task.FromResult(deviceListJson));
         }
 
         public const string ZWaveInterface = "Z-Wave";


### PR DESCRIPTION
- It is used if query to the open db z-wave database fails.
- Updated Nuget packages
